### PR TITLE
refactor(ui): simplify ComboBox implementation in main.qml

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -307,7 +307,7 @@ PlasmoidItem {
                 source: root.icon
                 Layout.alignment: Qt.AlignCenter
                 Layout.preferredHeight: 64
-                fillMode: Image.PreserveAspectFit               
+                fillMode: Image.PreserveAspectFit
             }
 
 
@@ -317,31 +317,21 @@ PlasmoidItem {
             }
 
 
-            PlasmaComponents3.ComboBox {
+            ComboBox {
                 Layout.alignment: Qt.AlignCenter
 
                 enabled: !root.loading && plasmoid.configuration.isCompatible
-                model: ListModel {
-                        ListElement { text: "Full Capacity"; value: "full" }
-                        ListElement { text: "Balanced (80%)"; value: "balanced" }
-                        ListElement { text: "Maximum Lifespan (60%)"; value: "maximum" }
-                }
-                
+                model: [
+                    {text: "Full Capacity", value: "full"},
+                    {text: "Balanced (80%)", value: "balanced"},
+                    {text: "Maximum Lifespan (60%)", value: "maximum"}
+                ]
                 textRole: "text"
                 valueRole: "value"
+                currentIndex: model.findIndex((element) => element.value === root.desiredStatus)
 
-                Component.onCompleted: {
-                    // Manually iterate to find the index
-                    for (var i = 0; i < model.count; i++) {
-                        if (model.get(i).value === root.desiredStatus) {
-                            currentIndex = i;
-                            break;
-                        }
-                    }
-                }
-
-                onActivated: {
-                    root.desiredStatus = currentValue
+                onCurrentIndexChanged: {
+                    root.desiredStatus = model[currentIndex].value                    
                     if (plasmoid.configuration.currentStatus && root.desiredStatus !== plasmoid.configuration.currentStatus) {
                         switchStatus()
                     }


### PR DESCRIPTION
Simplified the ComboBox component by directly initializing the `model` with an array, removing the custom `Component.onCompleted` block for setting the initial index, and utilizing `onCurrentIndexChanged` for updating `root.desiredStatus`. This fix a bug updating the currentIndex property in the combobox.