### PR TITLE
Update README for Plasma 6 installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note that there are two versions:
 
 ### Manually
 - Download/clone this repo.
-- Run from a terminal the command `plasmapkg2 -i [widget folder name]`.
+- Run from a terminal the command `kpackagetool6 -i [widget folder name]`.
 
 ## Disclaimer
 I'm not a widget or KDE developer, I did this by looking at other widgets, using AI chatbots, consulting documentation, etc. So use it at your own risk.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Note that there are two versions:
 
 ### Manually
 - Download/clone this repo.
-- Run from a terminal the command `kpackagetool6 -i [widget folder name]`.
+- Run from a terminal the command `kpackagetool6 -t Plasma/Applet -i [widget folder name]`.
 
 ## Disclaimer
 I'm not a widget or KDE developer, I did this by looking at other widgets, using AI chatbots, consulting documentation, etc. So use it at your own risk.


### PR DESCRIPTION
Since `plasmapkg2` is a Plasma 5 package, it is not available for pure Plasma 6 installation.
`kpackagetool6` command is a replacement for `plasmapkg2` on Plasma 6